### PR TITLE
Memory map by rows + shader folder copy in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,3 +17,5 @@ add_executable(vulkan_minimal_compute src/main.cpp src/vk_utils.h src/vk_utils.c
 set_target_properties(vulkan_minimal_compute PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
 
 target_link_libraries(vulkan_minimal_compute ${ALL_LIBS} )
+
+file(COPY shaders/ DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/shaders)


### PR DESCRIPTION
Исправлена ошибка мапа буферра в вектор-картинку: не все системы могут мапить большие объемы данных (может ли это быть в vkPhusikalDeviceInfo?). также теперь папка shaders копируется в папку build.